### PR TITLE
Fix multiple definition of buffer_init when linking with libmagic

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -23,13 +23,13 @@
  @param[in] len Size of data to be allocated for the buffer
  @return MOBIBuffer on success, NULL otherwise
  */
-MOBIBuffer * buffer_init(const size_t len) {
+MOBIBuffer * mobi_buffer_init(const size_t len) {
     unsigned char *data = malloc(len);
     if (data == NULL) {
         debug_print("%s", "Buffer data allocation failed\n");
         return NULL;
     }
-    MOBIBuffer *buf = buffer_init_null(data, len);
+    MOBIBuffer *buf = mobi_buffer_init_null(data, len);
     if (buf == NULL) {
         free(data);
     }
@@ -39,7 +39,7 @@ MOBIBuffer * buffer_init(const size_t len) {
 /**
  @brief Initializer for MOBIBuffer structure
  
- It allocates memory for structure but, unlike buffer_init(), it does not allocate memory for data.
+ It allocates memory for structure but, unlike mobi_buffer_init(), it does not allocate memory for data.
  Instead it works on external data.
  Memory should be freed with buffer_free_null() (buf->data will not be deallocated).
  
@@ -47,7 +47,7 @@ MOBIBuffer * buffer_init(const size_t len) {
  @param[in] len Size of data held by the buffer
  @return MOBIBuffer on success, NULL otherwise
  */
-MOBIBuffer * buffer_init_null(unsigned char *data, const size_t len) {
+MOBIBuffer * mobi_buffer_init_null(unsigned char *data, const size_t len) {
     MOBIBuffer *buf = malloc(sizeof(MOBIBuffer));
 	if (buf == NULL) {
         debug_print("%s", "Buffer allocation failed\n");
@@ -599,7 +599,7 @@ void buffer_setpos(MOBIBuffer *buf, const size_t pos) {
 /**
  @brief Free pointer to MOBIBuffer structure and pointer to data
  
- Free data initialized with buffer_init();
+ Free data initialized with mobi_buffer_init();
  
  @param[in] buf MOBIBuffer structure
  */
@@ -614,7 +614,7 @@ void buffer_free(MOBIBuffer *buf) {
 /**
  @brief Free pointer to MOBIBuffer structure
  
- Free data initialized with buffer_init_null();
+ Free data initialized with mobi_buffer_init_null();
  Unlike buffer_free() it will not free pointer to buf->data
  
  @param[in] buf MOBIBuffer structure

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -24,8 +24,8 @@ typedef struct {
     MOBI_RET error; /**< MOBI_SUCCESS = 0 if operation on buffer is successful, non-zero value on failure */
 } MOBIBuffer;
 
-MOBIBuffer * buffer_init(const size_t len);
-MOBIBuffer * buffer_init_null(unsigned char *data, const size_t len);
+MOBIBuffer * mobi_buffer_init(const size_t len);
+MOBIBuffer * mobi_buffer_init_null(unsigned char *data, const size_t len);
 void buffer_resize(MOBIBuffer *buf, const size_t newlen);
 void buffer_add8(MOBIBuffer *buf, const uint8_t data);
 void buffer_add16(MOBIBuffer *buf, const uint16_t data);

--- a/src/compression.c
+++ b/src/compression.c
@@ -31,12 +31,12 @@
  */
 MOBI_RET mobi_decompress_lz77(unsigned char *out, const unsigned char *in, size_t *len_out, const size_t len_in) {
     MOBI_RET ret = MOBI_SUCCESS;
-    MOBIBuffer *buf_in = buffer_init_null((unsigned char *) in, len_in);
+    MOBIBuffer *buf_in = mobi_buffer_init_null((unsigned char *) in, len_in);
     if (buf_in == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
     }
-    MOBIBuffer *buf_out = buffer_init_null(out, *len_out);
+    MOBIBuffer *buf_out = mobi_buffer_init_null(out, *len_out);
     if (buf_out == NULL) {
         buffer_free_null(buf_in);
         debug_print("%s\n", "Memory allocation failed");
@@ -199,12 +199,12 @@ static MOBI_RET mobi_decompress_huffman_internal(MOBIBuffer *buf_out, MOBIBuffer
  @return MOBI_RET status code (on success MOBI_SUCCESS)
  */
 MOBI_RET mobi_decompress_huffman(unsigned char *out, const unsigned char *in, size_t *len_out, size_t len_in, const MOBIHuffCdic *huffcdic) {
-    MOBIBuffer *buf_in = buffer_init_null((unsigned char *) in, len_in);
+    MOBIBuffer *buf_in = mobi_buffer_init_null((unsigned char *) in, len_in);
     if (buf_in == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
     }
-    MOBIBuffer *buf_out = buffer_init_null(out, *len_out);
+    MOBIBuffer *buf_out = mobi_buffer_init_null(out, *len_out);
     if (buf_out == NULL) {
         buffer_free_null(buf_in);
         debug_print("%s\n", "Memory allocation failed");

--- a/src/encryption.c
+++ b/src/encryption.c
@@ -184,7 +184,7 @@ static size_t mobi_drm_parse(MOBIDrm **drm, const MOBIData *m) {
     }
     /* First record */
     MOBIPdbRecord *rec = m->rec;
-    MOBIBuffer *buf = buffer_init_null(rec->data, rec->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(rec->data, rec->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return 0;
@@ -355,7 +355,7 @@ static MOBI_RET mobi_drm_getkey_v1(unsigned char key[KEYSIZE], const MOBIData *m
     }
     /* First record */
     MOBIPdbRecord *rec = m->rec;
-    MOBIBuffer *buf = buffer_init_null(rec->data, rec->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(rec->data, rec->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -516,7 +516,7 @@ EXTHDrm * mobi_exthdrm_get(const MOBIData *m) {
     if (meta == NULL) {
         return NULL;
     }
-    MOBIBuffer *buf = buffer_init_null(meta->data, meta->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(meta->data, meta->size);
     if (buf == NULL) {
         return NULL;
     }

--- a/src/index.c
+++ b/src/index.c
@@ -500,7 +500,7 @@ MOBI_RET mobi_parse_indx(const MOBIPdbRecord *indx_record, MOBIIndx *indx, MOBIT
         return MOBI_INIT_FAILED;
     }
     MOBI_RET ret = MOBI_SUCCESS;
-    MOBIBuffer *buf = buffer_init_null(indx_record->data, indx_record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(indx_record->data, indx_record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -827,7 +827,7 @@ bool mobi_indx_has_tag(const MOBIIndx *indx, const size_t tagid) {
  */
 char * mobi_get_cncx_string(const MOBIPdbRecord *cncx_record, const uint32_t cncx_offset) {
     /* TODO: handle multiple cncx records */
-    MOBIBuffer *buf = buffer_init_null(cncx_record->data, cncx_record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(cncx_record->data, cncx_record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return NULL;
@@ -880,7 +880,7 @@ char * mobi_get_cncx_string_utf8(const MOBIPdbRecord *cncx_record, const uint32_
  */
 char * mobi_get_cncx_string_flat(const MOBIPdbRecord *cncx_record, const uint32_t cncx_offset, const size_t length) {
     /* TODO: handle multiple cncx records */
-    MOBIBuffer *buf = buffer_init_null(cncx_record->data, cncx_record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(cncx_record->data, cncx_record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return NULL;

--- a/src/parse_rawml.c
+++ b/src/parse_rawml.c
@@ -650,7 +650,7 @@ MOBI_RET mobi_reconstruct_resources(const MOBIData *m, MOBIRawml *rawml) {
  */
 MOBI_RET mobi_process_replica(unsigned char *pdf, const char *text, size_t *length) {
     MOBI_RET ret = MOBI_SUCCESS;
-    MOBIBuffer *buf = buffer_init_null((unsigned char*) text, *length);
+    MOBIBuffer *buf = mobi_buffer_init_null((unsigned char*) text, *length);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -788,7 +788,7 @@ MOBI_RET mobi_reconstruct_parts(MOBIRawml *rawml) {
         return MOBI_INIT_FAILED;
     }
     /* take first part, xhtml */
-    MOBIBuffer *buf = buffer_init_null(rawml->flow->data, rawml->flow->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(rawml->flow->data, rawml->flow->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;

--- a/src/read.c
+++ b/src/read.c
@@ -33,7 +33,7 @@ MOBI_RET mobi_load_pdbheader(MOBIData *m, FILE *file) {
     if (!file) {
         return MOBI_FILE_NOT_FOUND;
     }
-    MOBIBuffer *buf = buffer_init(PALMDB_HEADER_LEN);
+    MOBIBuffer *buf = mobi_buffer_init(PALMDB_HEADER_LEN);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -91,7 +91,7 @@ MOBI_RET mobi_load_reclist(MOBIData *m, FILE *file) {
     }
     MOBIPdbRecord *curr = m->rec;
     for (int i = 0; i < m->ph->rec_count; i++) {
-        MOBIBuffer *buf = buffer_init(PALMDB_RECORD_INFO_SIZE);
+        MOBIBuffer *buf = mobi_buffer_init(PALMDB_RECORD_INFO_SIZE);
         if (buf == NULL) {
             debug_print("%s\n", "Memory allocation failed");
             return MOBI_MALLOC_FAILED;
@@ -430,7 +430,7 @@ MOBI_RET mobi_parse_record0(MOBIData *m, const size_t seqnumber) {
         debug_print("%s", "Record 0 too short\n");
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init_null(record0->data, record0->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(record0->data, record0->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -480,7 +480,7 @@ MOBI_RET mobi_parse_record0(MOBIData *m, const size_t seqnumber) {
  */
 size_t mobi_get_record_extrasize(const MOBIPdbRecord *record, const uint16_t flags) {
     size_t extra_size = 0;
-    MOBIBuffer *buf = buffer_init_null(record->data, record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(record->data, record->size);
     if (buf == NULL) {
         debug_print("%s", "Buffer init in extrasize failed\n");
         return MOBI_NOTSET;
@@ -519,7 +519,7 @@ size_t mobi_get_record_extrasize(const MOBIPdbRecord *record, const uint16_t fla
 size_t mobi_get_record_mb_extrasize(const MOBIPdbRecord *record, const uint16_t flags) {
     size_t extra_size = 0;
     if (flags & 1) {
-        MOBIBuffer *buf = buffer_init_null(record->data, record->size);
+        MOBIBuffer *buf = mobi_buffer_init_null(record->data, record->size);
         if (buf == NULL) {
             debug_print("%s", "Buffer init in extrasize failed\n");
             return MOBI_NOTSET;
@@ -554,7 +554,7 @@ size_t mobi_get_record_mb_extrasize(const MOBIPdbRecord *record, const uint16_t 
  @return MOBI_RET status code (on success MOBI_SUCCESS)
  */
 MOBI_RET mobi_parse_huff(MOBIHuffCdic *huffcdic, const MOBIPdbRecord *record) {
-    MOBIBuffer *buf = buffer_init_null(record->data, record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(record->data, record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -608,7 +608,7 @@ MOBI_RET mobi_parse_huff(MOBIHuffCdic *huffcdic, const MOBIPdbRecord *record) {
  @return MOBI_RET status code (on success MOBI_SUCCESS)
  */
 MOBI_RET mobi_parse_cdic(MOBIHuffCdic *huffcdic, const MOBIPdbRecord *record, const size_t num) {
-    MOBIBuffer *buf = buffer_init_null(record->data, record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(record->data, record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -775,7 +775,7 @@ MOBI_RET mobi_parse_fdst(const MOBIData *m, MOBIRawml *rawml) {
     if (fdst_record == NULL) {
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init_null(fdst_record->data, fdst_record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(fdst_record->data, fdst_record->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;

--- a/src/util.c
+++ b/src/util.c
@@ -1185,7 +1185,7 @@ MOBI_RET mobi_add_exthrecord(MOBIData *m, const MOBIExthTag tag, const uint32_t 
                 free(record);
                 return MOBI_PARAM_ERR;
             }
-            MOBIBuffer *buf = buffer_init_null(record->data, size);
+            MOBIBuffer *buf = mobi_buffer_init_null(record->data, size);
             if (buf == NULL) {
                 free(record->data);
                 free(record);
@@ -2106,7 +2106,7 @@ MOBI_RET mobi_decode_audio_resource(unsigned char **decoded_resource, size_t *de
         debug_print("Audio resource record too short (%zu)\n", part->size);
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init_null(part->data, part->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(part->data, part->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -2159,7 +2159,7 @@ MOBI_RET mobi_decode_video_resource(unsigned char **decoded_resource, size_t *de
         debug_print("Video resource record too short (%zu)\n", part->size);
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init_null(part->data, part->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(part->data, part->size);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -2270,7 +2270,7 @@ MOBI_RET mobi_get_embedded_log(unsigned char **data, size_t *size, const MOBIDat
         debug_print("Wrong size of CMET resource: %zu\n", srcs_record->size);
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init_null(srcs_record->data, srcs_record->size);
+    MOBIBuffer *buf = mobi_buffer_init_null(srcs_record->data, srcs_record->size);
     if (buf == NULL) {
         return MOBI_MALLOC_FAILED;
     }
@@ -2330,7 +2330,7 @@ MOBI_RET mobi_decode_font_resource(unsigned char **decoded_font, size_t *decoded
         debug_print("Font resource record too short (%zu)\n", part->size);
         return MOBI_DATA_CORRUPT;
     }
-    MOBIBuffer *buf = buffer_init(part->size);
+    MOBIBuffer *buf = mobi_buffer_init(part->size);
     if (buf == NULL) {
         debug_print("Memory allocation failed%s", "\n");
         return MOBI_MALLOC_FAILED;

--- a/src/write.c
+++ b/src/write.c
@@ -53,7 +53,7 @@ MOBI_RET mobi_write_pdbheader(FILE *file, const MOBIData *m) {
         debug_print("%s", "File not initialized\n");
         return MOBI_PARAM_ERR;
     }
-    MOBIBuffer *buf = buffer_init(PALMDB_HEADER_LEN);
+    MOBIBuffer *buf = mobi_buffer_init(PALMDB_HEADER_LEN);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -102,7 +102,7 @@ MOBI_RET mobi_serialize_mobiheader(MOBIBuffer *buf, const MOBIData *m, const uin
         debug_print("%s", "Mobi structure not initialized\n");
         return MOBI_INIT_FAILED;
     }
-    size_t buffer_init = buf->offset;
+    size_t mobi_buffer_init = buf->offset;
     buffer_addstring(buf, m->mh->mobi_magic);
     if (buf->offset > UINT32_MAX) {
         debug_print("Offset too large: %zu\n", buf->offset);
@@ -200,7 +200,7 @@ finalize:
     if (buf->error != MOBI_SUCCESS) {
         return MOBI_DATA_CORRUPT;
     }
-    size_t headersize = buf->offset - buffer_init;
+    size_t headersize = buf->offset - mobi_buffer_init;
     if (headersize > UINT32_MAX) {
          debug_print("Header too large: %zu\n", headersize);
         return MOBI_DATA_CORRUPT;
@@ -302,7 +302,7 @@ MOBI_RET mobi_update_record0(MOBIData *m, const size_t seqnumber) {
     record0_maxlen += exthsize;
     record0_maxlen += MOBI_TITLE_SIZEMAX;
     record0_maxlen += padding;
-    MOBIBuffer *buf = buffer_init(record0_maxlen);
+    MOBIBuffer *buf = mobi_buffer_init(record0_maxlen);
     if (buf == NULL) {
         debug_print("%s\n", "Memory allocation failed");
         return MOBI_MALLOC_FAILED;
@@ -391,7 +391,7 @@ MOBI_RET mobi_write_records(FILE *file, const MOBIData *m) {
         if (offset > UINT32_MAX) {
             return MOBI_DATA_CORRUPT;
         }
-        MOBIBuffer *buf = buffer_init(PALMDB_RECORD_INFO_SIZE);
+        MOBIBuffer *buf = mobi_buffer_init(PALMDB_RECORD_INFO_SIZE);
         if (buf == NULL) {
             return MOBI_MALLOC_FAILED;
         }

--- a/src/xmlwriter.c
+++ b/src/xmlwriter.c
@@ -370,7 +370,7 @@ xmlBufferPtr xmlBufferCreate(void) {
         return NULL;
     }
     unsigned int size = MOBI_XML_BUFFERSIZE;
-    MOBIBuffer *buf = buffer_init(size);
+    MOBIBuffer *buf = mobi_buffer_init(size);
     if (buf == NULL) {
         free(xmlbuf);
         return NULL;


### PR DESCRIPTION
Hi first of all thank you for the work you put in this library.

I'm using it in a project where it's statically linked with libmagic and I'm getting this error:

```
third-party/libscan/third-party/ext_libmobi/src/libmobi/src/.libs//libmobi.a(libmobi_la-buffer.o): In function `buffer_init':
/root/agent/work/f1ce04c709a195f3/third-party/libscan/third-party/ext_libmobi/src/libmobi/src/buffer.c:26: multiple definition of `buffer_init'
/vcpkg/installed/x64-linux/lib/libmagic.a(buffer.o):buffer.c:(.text+0x0): first defined here
collect2: error: ld returned 1 exit status
```

`buffer_init` in libmagic: [file.h](https://github.com/file/file/blob/master/src/file.h#L542) 

I managed to work around this by renaming the function to `mobi_buffer_init` in my fork. I'd appreciate we could merge this upstream (if you really want to keep the name it's fine but it would make my life much easier)

Thanks!