### PR TITLE
Fix 2 Out-of-bound Read issues inside the `mobi_decompress_huffman_internal`

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -146,6 +146,9 @@ static MOBI_RET mobi_decompress_huffman_internal(MOBIBuffer *buf_out, MOBIBuffer
                   return MOBI_DATA_CORRUPT;
             }
 
+            if (code_length >= (sizeof(huffcdic->maxcode_table) / sizeof(huffcdic->maxcode_table[0])) )
+                  return MOBI_DATA_CORRUPT;
+
             maxcode = huffcdic->maxcode_table[code_length];
         }
         bitcount -= code_length;

--- a/src/compression.c
+++ b/src/compression.c
@@ -141,7 +141,10 @@ static MOBI_RET mobi_decompress_huffman_internal(MOBIBuffer *buf_out, MOBIBuffer
         if (!(t1 & 0x80)) {
             /* get offset from mincode, maxcode tables */
             while (code < huffcdic->mincode_table[code_length]) {
-                code_length++;
+                if (code_length < (sizeof(huffcdic->mincode_table) / sizeof(huffcdic->mincode_table[0])) )
+                  code_length++;
+                else
+                  return MOBI_DATA_CORRUPT;
             }
             maxcode = huffcdic->maxcode_table[code_length];
         }

--- a/src/compression.c
+++ b/src/compression.c
@@ -141,11 +141,11 @@ static MOBI_RET mobi_decompress_huffman_internal(MOBIBuffer *buf_out, MOBIBuffer
         if (!(t1 & 0x80)) {
             /* get offset from mincode, maxcode tables */
             while (code < huffcdic->mincode_table[code_length]) {
-                if (code_length < (sizeof(huffcdic->mincode_table) / sizeof(huffcdic->mincode_table[0])) )
-                  code_length++;
-                else
+                code_length++;
+                if (code_length >= (sizeof(huffcdic->mincode_table) / sizeof(huffcdic->mincode_table[0])) )
                   return MOBI_DATA_CORRUPT;
             }
+
             maxcode = huffcdic->maxcode_table[code_length];
         }
         bitcount -= code_length;


### PR DESCRIPTION
This PR fixes two out-of-bound read issues #35 #36.
You should see more detail information from #35 #36.
And note that this only fixes problems I found inside `mobi_decompress_huffman_internal`, and there possibly have more incomplete checks of user-input data in similar functions inside the project.
Any more questions about securing libmobi is welcomed~