### PR TITLE
Export some useful api

### DIFF
--- a/src/mobi.h
+++ b/src/mobi.h
@@ -472,6 +472,7 @@ extern "C"
      @defgroup mobi_export Functions exported by the library
      @{
      */
+    MOBI_EXPORT const char * libmobi_msg(const MOBI_RET ret);
     MOBI_EXPORT const char * mobi_version(void);
     MOBI_EXPORT MOBI_RET mobi_load_file(MOBIData *m, FILE *file);
     MOBI_EXPORT MOBI_RET mobi_load_filename(MOBIData *m, const char *path);
@@ -506,6 +507,8 @@ extern "C"
     MOBI_EXPORT uint16_t mobi_get_textrecord_maxsize(const MOBIData *m);
     MOBI_EXPORT size_t mobi_get_kf8offset(const MOBIData *m);
     MOBI_EXPORT size_t mobi_get_kf8boundary_seqnumber(const MOBIData *m);
+    MOBI_EXPORT uint32_t mobi_get_orth_entry_start_offset(const MOBIIndexEntry* m);
+    MOBI_EXPORT uint32_t mobi_get_orth_entry_text_length(const MOBIIndexEntry* m);
     MOBI_EXPORT size_t mobi_get_record_extrasize(const MOBIPdbRecord *record, const uint16_t flags);
     MOBI_EXPORT size_t mobi_get_record_mb_extrasize(const MOBIPdbRecord *record, const uint16_t flags);
     MOBI_EXPORT size_t mobi_get_fileversion(const MOBIData *m);

--- a/src/util.c
+++ b/src/util.c
@@ -67,6 +67,42 @@ static const unsigned char cp1252_to_utf8[32][3] = {
 };
 
 /**
+ @brief Messages for libmobi return codes
+ For reference see enum MOBI_RET in mobi.h
+ */
+const char *libmobi_messages[] = {
+    "Success",
+    "Generic error",
+    "Wrong function parameter",
+    "Corrupted data",
+    "File not found",
+    "Document is encrypted",
+    "Unsupported document format",
+    "Memory allocation error",
+    "Initialization error",
+    "Buffer error",
+    "XML error",
+    "Invalid DRM pid",
+    "DRM key not found",
+    "DRM support not included",
+};
+
+#define LIBMOBI_MSG_COUNT ARRAYSIZE(libmobi_messages)
+
+/**
+ @brief Return message for given libmobi return code
+ @param[in] ret Libmobi return code
+ */
+const char * libmobi_msg(const MOBI_RET ret) {
+    size_t index = ret;
+    if (index < LIBMOBI_MSG_COUNT) {
+        return libmobi_messages[index];
+    } else {
+        return "Unknown error";
+    }
+}
+
+/**
  @brief Get libmobi version
 
  @return String version
@@ -2827,6 +2863,39 @@ uint32_t mobi_get_exthsize(const MOBIData *m) {
     } else {
         return (uint32_t) size;
     }
+}
+
+/**
+ @brief Get entry start offset for the orth entry
+
+ @param[in] m MOBIIndexEntry structure
+ @return Start offset, -1 on failure
+*/
+uint32_t mobi_get_orth_entry_start_offset(const MOBIIndexEntry* m) {
+    uint32_t entry_startpos;
+    MOBI_RET ret = mobi_get_indxentry_tagvalue(&entry_startpos, m,
+                                               INDX_TAG_ORTH_STARTPOS);
+    if (ret != MOBI_SUCCESS)
+        return -1;
+
+    return entry_startpos;
+}
+
+/**
+ @brief Get text length for the orth entry
+
+ @param[in] MOBIIndexEntry structure
+ @return Text length, -1 on failure
+*/
+uint32_t mobi_get_orth_entry_text_length(const MOBIIndexEntry* m) {
+    uint32_t entry_textlen;
+    MOBI_RET ret = mobi_get_indxentry_tagvalue(&entry_textlen, m,
+                                               INDX_TAG_ORTH_ENDPOS);
+
+    if (ret != MOBI_SUCCESS)
+        return -1;
+
+    return entry_textlen;
 }
 
 /**

--- a/tools/common.c
+++ b/tools/common.c
@@ -28,42 +28,6 @@ const char separator = '/';
 #endif
 
 /**
- @brief Messages for libmobi return codes
- For reference see enum MOBI_RET in mobi.h
- */
-const char *libmobi_messages[] = {
-    "Success",
-    "Generic error",
-    "Wrong function parameter",
-    "Corrupted data",
-    "File not found",
-    "Document is encrypted",
-    "Unsupported document format",
-    "Memory allocation error",
-    "Initialization error",
-    "Buffer error",
-    "XML error",
-    "Invalid DRM pid",
-    "DRM key not found",
-    "DRM support not included",
-};
-
-#define LIBMOBI_MSG_COUNT ARRAYSIZE(libmobi_messages)
-
-/**
- @brief Return message for given libmobi return code
- @param[in] ret Libmobi return code
- */
-const char * libmobi_msg(const MOBI_RET ret) {
-    size_t index = ret;
-    if (index < LIBMOBI_MSG_COUNT) {
-        return libmobi_messages[index];
-    } else {
-        return "Unknown error";
-    }
-}
-
-/**
  @brief Parse file name into file path and base name.
         Dirname or basename can be skipped by setting to null.
         All buffers must have FILENAME_MAX size.

--- a/tools/common.h
+++ b/tools/common.h
@@ -54,7 +54,6 @@
 #define FULLNAME_MAX 1024
 
 extern const char separator;
-const char * libmobi_msg(const MOBI_RET ret);
 void split_fullpath(const char *fullpath, char *dirname, char *basename);
 int make_directory(const char *path);
 int create_subdir(char *newdir, const char *dir, const char *name);


### PR DESCRIPTION
Hi Bartek, I'm currently writing a dictionary software and want to add mobi dict support to it. I'm glad to find there is such a great mobi library!
This PR is basically what I found i ismail's mobdict project, so credits to him. It adds two useful functions to get the start and length of an entry. And since getting the error string is such a useful function I also exports `libmobi_msg`. Let me know what do you think of it. :)